### PR TITLE
inline: Set Help Topic Refresh Statuses

### DIFF
--- a/scp/js/ticket.js
+++ b/scp/js/ticket.js
@@ -366,6 +366,17 @@ var ticket_onload = function($) {
                 $('#msg-txt').text(obj.msg);
                 $('div#msg_notice').show();
             }
+            // If Help Topic was set and statuses are returned
+            if (obj.statuses) {
+                var el = $('select[name=reply_status_id]');
+                // Foreach status see if exists, if not appned to options
+                $.each(obj.statuses, function(key, value) {
+                    if (el.find('option[value='+key+']').length == 0)
+                        el.append($('<option></option>').attr('value', key).text(value));
+                });
+                // Hide warning banner
+                el.closest('td').find('.warning-banner').hide();
+            }
         }, $options);
 
         return false;


### PR DESCRIPTION
This addresses issue 5316 where having `Require Help Topic to Close` Enabled
and setting a Help Topic via Inline Edit will not let you Close the ticket
via response box unless you refresh the page. This is due to Inline Edit not
refreshing the statues in the dropdown to select from. This adds a check in
`include/ajax.tickets.php` that checks for if we Require HT On Close, if the
ticket is open, if the staff has permission to close, and if we set a help
topic. If all of this is true we gather all of the Closed statuses and
return them in the response as `statuses`. In addition, this adds a check in
the AJAX success to see if `statuses` were returned. If so, we loop through
each, see if they already exist in the list and if not we append them as new
options. After we add all of the statues we then hide the warning banner. At
this point the agent can close the ticket via response box if they choose to
do so.