### PR TITLE
Issue: Close Child Ticket Without Help Topic

### DIFF
--- a/include/class.ticket.php
+++ b/include/class.ticket.php
@@ -331,7 +331,7 @@ implements RestrictedAccess, Threadable, Searchable {
         } elseif (($num=$this->getNumOpenTasks())) {
             $warning = sprintf(__('%1$s has %2$d open tasks and cannot be closed'),
                     __('This ticket'), $num);
-        } elseif ($cfg->requireTopicToClose() && !$this->getTopicId()) {
+        } elseif ($cfg->requireTopicToClose() && !$this->getTopicId() && !$this->isChild()) {
             $warning = sprintf(
                     __( '%1$s is missing a %2$s and cannot be closed'),
                     __('This ticket'), __('Help Topic'), '');


### PR DESCRIPTION
When merging Tickets, we automatically set children Tickets to a closed status, however, we had an issue with child Tickets that did not have a Help Topic. If the helpdesk had the 'Require Help Topic to Close' configuration, the children Tickets would not close as expected.

This fixes Issue #5317