### PR TITLE
refactor: Help Topic Status Refresh

### DIFF
--- a/scp/js/scp.js
+++ b/scp/js/scp.js
@@ -1373,7 +1373,7 @@ $(document).on('click.inline-edit', 'a.inline-edit', function(e) {
                             reply.append(option);
                     if (note)
                         if (note.find('option[value='+key+']').length == 0)
-                            note.append(option);
+                            note.append(option.clone());
                 });
                 // Hide warning banner
                 reply.closest('td').find('.warning-banner').hide();


### PR DESCRIPTION
This addresses an issue where setting a Help Topic via Inline Edit does not
refresh the statuses in the Reply box, but it does refresh the statuses in
the Internal Note box. This is due to jQuery not being able to append the
same `<option>` object to multiple `<select>` objects. When you use the same
`<option>` object for multiple `<selelct>` objects, it removes the object
from the first `<select>` and appends it to the second `<select>`. Instead
of reusing the same object we must clone it so it does not interfere with
the first `<select>`.